### PR TITLE
Converting between wally.toml and jelly.json

### DIFF
--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -246,6 +246,50 @@ jelly runtimes
 - Unavailable runtimes that could be installed
 - Status of each runtime (available/not available)
 
+### `jelly convert-wally`
+
+Convert a wally.toml file to jelly.json format.
+
+**Options:**
+
+- `-i, --input <file>`: Input wally.toml file (default: wally.toml)
+- `-o, --output <file>`: Output jelly.json file (default: jelly.json)
+
+**Examples:**
+
+```bash
+# Convert wally.toml to jelly.json (default files)
+jelly convert-wally
+
+# Convert specific files
+jelly convert-wally -i my-wally.toml -o my-jelly.json
+
+# Convert with custom output location
+jelly convert-wally -o config/jelly.json
+```
+
+### `jelly convert-jelly`
+
+Convert a jelly.json file to wally.toml format.
+
+**Options:**
+
+- `-i, --input <file>`: Input jelly.json file (default: jelly.json)
+- `-o, --output <file>`: Output wally.toml file (default: wally.toml)
+
+**Examples:**
+
+```bash
+# Convert jelly.json to wally.toml (default files)
+jelly convert-jelly
+
+# Convert specific files
+jelly convert-jelly -i my-jelly.json -o my-wally.toml
+
+# Convert with custom input location
+jelly convert-jelly -i config/jelly.json
+```
+
 ## Lockfile Commands
 
 ### `jelly lockfile [options]`

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -44,7 +44,8 @@ Jelly uses a `jelly.json` file to manage project dependencies and configuration.
   "jelly": {
     "cleanup": true,
     "optimize": true,
-    "packagesPath": "Packages"
+    "packagesPath": "Packages",
+    "updateProjectFile": true
   }
 }
 ```
@@ -70,6 +71,25 @@ Jelly uses a `jelly.json` file to manage project dependencies and configuration.
 - **Type**: `string`
 - **Description**: A brief description of your project
 - **Example**: `"My awesome Roblox game"`
+
+#### `private` (optional)
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: Marks the package as private, preventing it from being published to registries. Set to `true` to prevent accidental publishing of private packages.
+- **Example**: `"private": true`
+
+#### `license` (optional)
+
+- **Type**: `string`
+- **Description**: The license under which your package is published
+- **Example**: `"MIT"`
+
+#### `authors` (optional)
+
+- **Type**: `string[]`
+- **Description**: List of package authors
+- **Example**: `["John Doe <john@example.com>"]`
 
 ### Dependencies
 
@@ -213,6 +233,13 @@ Jelly uses a `jelly.json` file to manage project dependencies and configuration.
 - **Default**: `"Packages"`
 - **Description**: Path where packages should be installed
 - **Example**: `"packagesPath": "Dependencies"`
+
+##### `jelly.updateProjectFile`
+
+- **Type**: `boolean`
+- **Default**: `true`
+- **Description**: Whether to automatically update Rojo project files (default.project.json) to include the Packages directory. Set to `false` if you don't use Rojo or manage your project structure manually.
+- **Example**: `"updateProjectFile": false`
 
 ## Project Structure
 
@@ -422,4 +449,49 @@ Define common development tasks in scripts:
     "clean": "jelly clean"
   }
 }
+```
+
+## Publishing Guidelines
+
+When publishing packages to the Wally registry, Jelly enforces several guidelines to ensure package quality and compatibility.
+
+### Package Size Limit
+
+Packages must not exceed **2MB** in total size (compressed). This follows Wally's guidelines and ensures fast downloads. If your package exceeds this limit:
+
+- Use the `exclude` field to remove unnecessary files
+- Remove large assets or documentation that can be hosted separately
+- Consider splitting large packages into smaller, focused packages
+
+### Private Packages
+
+Packages marked as `private: true` cannot be published. This prevents accidental publishing of internal or development packages:
+
+```json
+{
+  "name": "my-company/internal-tools",
+  "private": true,
+  "dependencies": {}
+}
+```
+
+### Required Fields for Publishing
+
+The following fields are required when publishing:
+
+- `name`: Must be in `scope/name` format
+- `version`: Must follow semantic versioning (e.g., `1.0.0`)
+- `src/`: Directory must exist and contain your package code
+
+### Publishing Commands
+
+```bash
+# Publish your package
+jelly publish
+
+# Test publishing without actually publishing
+jelly publish --dry-run
+
+# Create a package archive locally
+jelly package
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "minimatch": "^10.0.3",
         "node-fetch": "^2.7.0",
         "ora": "^5.4.1",
-        "semver": "^7.7.2"
+        "semver": "^7.7.2",
+        "smol-toml": "^1.4.1"
       },
       "bin": {
         "jd": "dist/src/bin/jelly.js",
@@ -5183,6 +5184,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
+      "integrity": "sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "minimatch": "^10.0.3",
     "node-fetch": "^2.7.0",
     "ora": "^5.4.1",
-    "semver": "^7.7.2"
+    "semver": "^7.7.2",
+    "smol-toml": "^1.4.1"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.5",

--- a/src/bin/jelly.ts
+++ b/src/bin/jelly.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import * as fs from 'fs-extra';
 import { JellyManager } from '../lib/managers/JellyManager';
 import { AuthManager } from '../lib/managers/AuthManager';
 import { PublishManager } from '../lib/managers/PublishManager';
@@ -396,6 +397,56 @@ program
   });
 
 program
+  .command('convert-wally')
+  .description('Convert wally.toml to jelly.json')
+  .option('-i, --input <file>', 'input wally.toml file')
+  .option('-o, --output <file>', 'output jelly.json file')
+  .action(async (input?: string, output?: string, options?: any) => {
+    try {
+      // Use positional args first, then options, then defaults
+      const inputPath = input || options?.input || 'wally.toml';
+      const outputPath = output || options?.output || 'jelly.json';
+
+      if (!await fs.pathExists(inputPath)) {
+        Output.error(`Input file not found: ${inputPath}`);
+        process.exit(1);
+      }
+
+      const { convertWallyTomlToJellyJson } = await import('../lib/utils/conversion');
+      await convertWallyTomlToJellyJson(inputPath, outputPath);
+      Output.success(`Converted ${inputPath} to ${outputPath}`);
+    } catch (error) {
+      Output.error('Conversion failed', (error as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('convert-jelly')
+  .description('Convert jelly.json to wally.toml')
+  .option('-i, --input <file>', 'input jelly.json file')
+  .option('-o, --output <file>', 'output wally.toml file')
+  .action(async (input?: string, output?: string, options?: any) => {
+    try {
+      // Use positional args first, then options, then defaults
+      const inputPath = input || options?.input || 'jelly.json';
+      const outputPath = output || options?.output || 'wally.toml';
+
+      if (!await fs.pathExists(inputPath)) {
+        Output.error(`Input file not found: ${inputPath}`);
+        process.exit(1);
+      }
+
+      const { convertJellyJsonToWallyToml } = await import('../lib/utils/conversion');
+      await convertJellyJsonToWallyToml(inputPath, outputPath);
+      Output.success(`Converted ${inputPath} to ${outputPath}`);
+    } catch (error) {
+      Output.error('Conversion failed', (error as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
   .command('exec <package>')
   .alias('x')
   .description('Execute a binary package (checks local first, then downloads if needed)')
@@ -438,5 +489,7 @@ program
       process.exit(1);
     }
   });
+
+
 
 program.parse(process.argv);

--- a/src/lib/managers/LockfileManager.ts
+++ b/src/lib/managers/LockfileManager.ts
@@ -71,7 +71,7 @@ export class LockfileManager {
       if (versionInfo) {
         lockfile.packages[packageName] = {
           version: resolved.version,
-          resolved: `https://api.wally.run/v1/package-contents/${packageName}/${resolved.version}`,
+          resolved: WallyAPI.getDownloadUrl(packageName.split('/')[0], packageName.split('/')[1], resolved.version),
           dependencies: versionInfo.dependencies || {},
           devDependencies: versionInfo['dev-dependencies'] || {}
         };
@@ -112,7 +112,7 @@ export class LockfileManager {
         const lockfileKey = `${parsed.scope}/${parsed.name}`;
         packages[lockfileKey] = {
           version: resolvedVersion,
-          resolved: `https://api.wally.run/v1/package-contents/${parsed.scope}/${parsed.name}/${resolvedVersion}`,
+          resolved: WallyAPI.getDownloadUrl(parsed.scope, parsed.name, resolvedVersion),
           dependencies: versionInfo.dependencies || {},
           devDependencies: versionInfo['dev-dependencies'] || {}
         };

--- a/src/lib/managers/ProjectManager.ts
+++ b/src/lib/managers/ProjectManager.ts
@@ -170,7 +170,8 @@ export class ProjectManager {
       jelly: {
         cleanup: true,
         optimize: true,
-        packagesPath: "Packages"
+        packagesPath: "Packages",
+        updateProjectFile: true // Can be disabled by users who don't use Rojo or Argon
       }
     };
 
@@ -212,6 +213,7 @@ export class ProjectManager {
       license: "MIT",
       authors: [authorInfo],
       realm: "shared",
+      registry: "https://github.com/upliftgames/wally-index",
       include: [
         "README.md",
         "src/**",
@@ -229,7 +231,8 @@ export class ProjectManager {
       jelly: {
         cleanup: true,
         optimize: true,
-        packagesPath: "Packages"
+        packagesPath: "Packages",
+        updateProjectFile: true // Can be disabled by users who don't use Rojo
       }
     };
 

--- a/src/lib/managers/RuntimeManager.ts
+++ b/src/lib/managers/RuntimeManager.ts
@@ -236,7 +236,7 @@ async checkRuntimeAvailable(command: string): Promise<boolean> {
       Output.newLine();
       Output.warning('This command will download and execute a package from the Wally registry:');
       Output.log(`  Package: ${packageDisplayName}`);
-      Output.log(`  Registry: https://api.wally.run`);
+      Output.log(`  Registry: Using configured registry`);  // TODO: Show actual registry from config
       Output.newLine();
       
       // Use readline to prompt for confirmation

--- a/src/lib/managers/VersionResolver.ts
+++ b/src/lib/managers/VersionResolver.ts
@@ -19,13 +19,13 @@ export interface DependencyConflict {
 export class VersionResolver {
   private packageCache = new Map<string, WallyPackageInfo>();
 
-  async resolveVersion(scope: string, name: string, versionRange: string): Promise<ResolvedVersion> {
+  async resolveVersion(scope: string, name: string, versionRange: string, registry?: string): Promise<ResolvedVersion> {
     const packageName = `${scope}/${name}`;
     
     // Get package info (with caching)
     let packageInfo = this.packageCache.get(packageName);
     if (!packageInfo) {
-      packageInfo = await WallyAPI.getPackageInfo(scope, name);
+      packageInfo = await WallyAPI.getPackageInfo(scope, name, registry);
       this.packageCache.set(packageName, packageInfo);
     }
 

--- a/src/lib/utils/conversion.ts
+++ b/src/lib/utils/conversion.ts
@@ -1,0 +1,214 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { JellyConfig } from '../../types';
+import { parse, stringify } from 'smol-toml';
+
+interface TomlParser {
+  parse(content: string): any;
+  stringify(obj: any): string;
+}
+
+// TOML parser using smol-toml
+const toml: TomlParser = {
+  parse: (content: string) => {
+    return parse(content);
+  },
+  stringify: (obj: any) => {
+    return stringify(obj);
+  }
+};
+
+export interface WallyToml {
+  package: {
+    name: string;
+    description?: string;
+    version: string;
+    license?: string;
+    authors?: string[];
+    realm?: 'shared' | 'server';
+    registry?: string;
+    homepage?: string;
+    repository?: string;
+    include?: string[];
+    exclude?: string[];
+    private?: boolean;
+  };
+  dependencies?: Record<string, string>;
+  'server-dependencies'?: Record<string, string>;
+  'dev-dependencies'?: Record<string, string>;
+}
+
+/**
+ * Convert wally.toml to jelly.json format
+ */
+export function wallyTomlToJellyJson(wallyConfig: WallyToml): JellyConfig {
+  const jellyConfig: JellyConfig = {
+    name: wallyConfig.package.name,
+    version: wallyConfig.package.version,
+    dependencies: wallyConfig.dependencies || {},
+    devDependencies: wallyConfig['dev-dependencies'] || {},
+  };
+
+  // Optional fields
+  if (wallyConfig.package.description) {
+    jellyConfig.description = wallyConfig.package.description;
+  }
+  
+  if (wallyConfig.package.license) {
+    jellyConfig.license = wallyConfig.package.license;
+  }
+  
+  if (wallyConfig.package.authors) {
+    jellyConfig.authors = wallyConfig.package.authors;
+  }
+  
+  if (wallyConfig.package.realm) {
+    jellyConfig.realm = wallyConfig.package.realm;
+  }
+  
+  if (wallyConfig.package.registry) {
+    jellyConfig.registry = wallyConfig.package.registry;
+  }
+  
+  if (wallyConfig.package.homepage) {
+    jellyConfig.homepage = wallyConfig.package.homepage;
+  }
+  
+  if (wallyConfig.package.repository) {
+    jellyConfig.repository = wallyConfig.package.repository;
+  }
+  
+  if (wallyConfig.package.include) {
+    jellyConfig.include = wallyConfig.package.include;
+  }
+  
+  if (wallyConfig.package.exclude) {
+    jellyConfig.exclude = wallyConfig.package.exclude;
+  }
+  
+  if (wallyConfig.package.private) {
+    jellyConfig.private = wallyConfig.package.private;
+  }
+  
+  if (wallyConfig['server-dependencies']) {
+    jellyConfig.serverDependencies = wallyConfig['server-dependencies'];
+  }
+
+  return jellyConfig;
+}
+
+/**
+ * Convert jelly.json to wally.toml format
+ */
+export function jellyJsonToWallyToml(jellyConfig: JellyConfig): WallyToml {
+  const wallyConfig: WallyToml = {
+    package: {
+      name: jellyConfig.name,
+      version: jellyConfig.version,
+    },
+  };
+
+  // Optional fields
+  if (jellyConfig.description) {
+    wallyConfig.package.description = jellyConfig.description;
+  }
+  
+  if (jellyConfig.license) {
+    wallyConfig.package.license = jellyConfig.license;
+  }
+  
+  if (jellyConfig.authors) {
+    wallyConfig.package.authors = jellyConfig.authors;
+  }
+  
+  if (jellyConfig.realm) {
+    wallyConfig.package.realm = jellyConfig.realm;
+  }
+  
+  if (jellyConfig.registry) {
+    wallyConfig.package.registry = jellyConfig.registry;
+  }
+  
+  if (jellyConfig.homepage) {
+    wallyConfig.package.homepage = jellyConfig.homepage;
+  }
+  
+  if (jellyConfig.repository) {
+    wallyConfig.package.repository = jellyConfig.repository;
+  }
+  
+  if (jellyConfig.include) {
+    wallyConfig.package.include = jellyConfig.include;
+  }
+  
+  if (jellyConfig.exclude) {
+    wallyConfig.package.exclude = jellyConfig.exclude;
+  }
+  
+  if (jellyConfig.private) {
+    wallyConfig.package.private = jellyConfig.private;
+  }
+
+  // Dependencies
+  if (Object.keys(jellyConfig.dependencies).length > 0) {
+    wallyConfig.dependencies = jellyConfig.dependencies;
+  }
+  
+  if (jellyConfig.devDependencies && Object.keys(jellyConfig.devDependencies).length > 0) {
+    wallyConfig['dev-dependencies'] = jellyConfig.devDependencies;
+  }
+  
+  if (jellyConfig.serverDependencies && Object.keys(jellyConfig.serverDependencies).length > 0) {
+    wallyConfig['server-dependencies'] = jellyConfig.serverDependencies;
+  }
+
+  return wallyConfig;
+}
+
+/**
+ * Read and parse wally.toml file
+ */
+export async function readWallyToml(filePath: string): Promise<WallyToml> {
+  const content = await fs.readFile(filePath, 'utf-8');
+  return toml.parse(content) as WallyToml;
+}
+
+/**
+ * Write wally.toml file
+ */
+export async function writeWallyToml(filePath: string, config: WallyToml): Promise<void> {
+  const content = toml.stringify(config);
+  await fs.writeFile(filePath, content);
+}
+
+/**
+ * Read and parse jelly.json file
+ */
+export async function readJellyJson(filePath: string): Promise<JellyConfig> {
+  return await fs.readJson(filePath);
+}
+
+/**
+ * Write jelly.json file
+ */
+export async function writeJellyJson(filePath: string, config: JellyConfig): Promise<void> {
+  await fs.writeJson(filePath, config, { spaces: 2 });
+}
+
+/**
+ * Convert wally.toml file to jelly.json
+ */
+export async function convertWallyTomlToJellyJson(inputPath: string, outputPath: string): Promise<void> {
+  const wallyConfig = await readWallyToml(inputPath);
+  const jellyConfig = wallyTomlToJellyJson(wallyConfig);
+  await writeJellyJson(outputPath, jellyConfig);
+}
+
+/**
+ * Convert jelly.json file to wally.toml
+ */
+export async function convertJellyJsonToWallyToml(inputPath: string, outputPath: string): Promise<void> {
+  const jellyConfig = await readJellyJson(inputPath);
+  const wallyConfig = jellyJsonToWallyToml(jellyConfig);
+  await writeWallyToml(outputPath, wallyConfig);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,9 +9,9 @@ export interface RojoProject {
 }
 
 export interface BinaryPackageTarget {
-  environment: string; // e.g., "lune", "luau", "python", "node", etc.
-  bin: string; // Entry point file, e.g., "main.luau", "cli.py", "index.js"
-  args?: string[]; // Optional default arguments
+  environment: string;
+  bin: string;
+  args?: string[];
 }
 
 export interface JellyConfig {
@@ -20,7 +20,7 @@ export interface JellyConfig {
   description?: string;
   license?: string;
   authors?: string[];
-  realm?: 'shared' | 'server' | 'development';
+  realm?: 'shared' | 'server';
   registry?: string;
   homepage?: string;
   repository?: string;
@@ -36,6 +36,7 @@ export interface JellyConfig {
     cleanup?: boolean;
     optimize?: boolean;
     packagesPath?: string;
+    updateProjectFile?: boolean; // Whether to automatically update Rojo project files
   };
 }
 
@@ -149,7 +150,7 @@ export interface WallyManifest {
     name: string;
     version: string;
     registry?: string;
-    realm?: 'shared' | 'server' | 'development';
+    realm?: 'shared' | 'server';
     description?: string;
     license?: string;
     authors?: string[];


### PR DESCRIPTION
add commands for converting between wally.toml and jelly.json formats

- Implemented `jelly convert-wally` and `jelly convert-jelly` commands for file format conversion.
- Updated documentation to include usage examples for the new commands.

feat: enhance jelly.json configuration options

- Added optional fields: `private`, `license`, `authors`, and `updateProjectFile` to `jelly.json`.
- Updated project structure and configuration documentation accordingly.

fix: improve package publishing guidelines

- Enforced package size limit of 2MB for publishing.
- Added validation for private packages to prevent accidental publishing.

refactor: update project file handling in JellyManager

- Introduced method to conditionally update the Rojo project file based on user configuration.
- Improved error handling during project file updates.

fix: update Wally API integration for dynamic registry support

- Modified API calls to use a configurable registry URL.
- Updated methods to fetch package information and download URLs based on the specified registry.

chore: add conversion utilities for wally.toml and jelly.json

- Created utility functions for reading, writing, and converting between wally.toml and jelly.json formats.
- Integrated conversion utilities into the publish and convert commands.